### PR TITLE
Fix rename support in patch parser

### DIFF
--- a/codex-cli/src/parse-apply-patch.ts
+++ b/codex-cli/src/parse-apply-patch.ts
@@ -12,6 +12,8 @@ export type ApplyPatchDeleteFileOp = {
 export type ApplyPatchUpdateFileOp = {
   type: "update";
   path: string;
+  /** Optional new path when the file is moved */
+  newPath?: string;
   update: string;
   added: number;
   deleted: number;
@@ -72,10 +74,18 @@ export function parseApplyPatch(patch: string): Array<ApplyPatchOp> | null {
       ops.push({
         type: "update",
         path: line.slice(UPDATE_FILE_PREFIX.length).trim(),
+        newPath: undefined,
         update: "",
         added: 0,
         deleted: 0,
       });
+      continue;
+    } else if (line.startsWith(MOVE_FILE_TO_PREFIX)) {
+      const lastOp = ops[ops.length - 1];
+      if (lastOp?.type !== "update" || lastOp.update) {
+        return null;
+      }
+      lastOp.newPath = line.slice(MOVE_FILE_TO_PREFIX.length).trim();
       continue;
     }
 

--- a/codex-cli/src/parse-apply-patch.ts
+++ b/codex-cli/src/parse-apply-patch.ts
@@ -82,7 +82,7 @@ export function parseApplyPatch(patch: string): Array<ApplyPatchOp> | null {
       continue;
     } else if (line.startsWith(MOVE_FILE_TO_PREFIX)) {
       const lastOp = ops[ops.length - 1];
-      if (lastOp?.type !== "update" || lastOp.update) {
+      if (lastOp?.type !== "update" || lastOp.update.length > 0) {
         return null;
       }
       lastOp.newPath = line.slice(MOVE_FILE_TO_PREFIX.length).trim();

--- a/codex-cli/src/utils/agent/parse-apply-patch.ts
+++ b/codex-cli/src/utils/agent/parse-apply-patch.ts
@@ -74,7 +74,6 @@ export function parseApplyPatch(patch: string): Array<ApplyPatchOp> | null {
       ops.push({
         type: "update",
         path: line.slice(UPDATE_FILE_PREFIX.length).trim(),
-        newPath: undefined,
         update: "",
         added: 0,
         deleted: 0,

--- a/codex-cli/src/utils/agent/parse-apply-patch.ts
+++ b/codex-cli/src/utils/agent/parse-apply-patch.ts
@@ -12,6 +12,8 @@ export type ApplyPatchDeleteFileOp = {
 export type ApplyPatchUpdateFileOp = {
   type: "update";
   path: string;
+  /** Optional new path when the file is moved */
+  newPath?: string;
   update: string;
   added: number;
   deleted: number;
@@ -27,6 +29,7 @@ const PATCH_SUFFIX = "\n*** End Patch";
 const ADD_FILE_PREFIX = "*** Add File: ";
 const DELETE_FILE_PREFIX = "*** Delete File: ";
 const UPDATE_FILE_PREFIX = "*** Update File: ";
+const MOVE_FILE_TO_PREFIX = "*** Move to: ";
 const END_OF_FILE_PREFIX = "*** End of File";
 const HUNK_ADD_LINE_PREFIX = "+";
 
@@ -71,10 +74,18 @@ export function parseApplyPatch(patch: string): Array<ApplyPatchOp> | null {
       ops.push({
         type: "update",
         path: line.slice(UPDATE_FILE_PREFIX.length).trim(),
+        newPath: undefined,
         update: "",
         added: 0,
         deleted: 0,
       });
+      continue;
+    } else if (line.startsWith(MOVE_FILE_TO_PREFIX)) {
+      const lastOp = ops[ops.length - 1];
+      if (lastOp?.type !== "update" || lastOp.update) {
+        return null;
+      }
+      lastOp.newPath = line.slice(MOVE_FILE_TO_PREFIX.length).trim();
       continue;
     }
 

--- a/codex-cli/tests/parse-apply-patch.test.ts
+++ b/codex-cli/tests/parse-apply-patch.test.ts
@@ -38,6 +38,23 @@ describe("parseApplyPatch", () => {
     ]);
   });
 
+  test("parses update operations with a move", () => {
+    const patch = `*** Begin Patch\n*** Update File: old.txt\n*** Move to: new.txt\n@@\n-old\n+new\n*** End Patch`;
+
+    const ops = mustParse(patch);
+
+    expect(ops).toEqual([
+      {
+        type: "update",
+        path: "old.txt",
+        newPath: "new.txt",
+        update: "@@\n-old\n+new",
+        added: 1,
+        deleted: 1,
+      },
+    ]);
+  });
+
   test("returns null for an invalid patch (missing prefix)", () => {
     const invalid = `*** Add File: foo.txt\n+bar\n*** End Patch`;
     expect(parseApplyPatch(invalid)).toBeNull();


### PR DESCRIPTION
## Summary
- handle `*** Move to:` lines in `parseApplyPatch`
- expose moved path via `newPath`
- test parsing patches that rename files

## Testing
- `pnpm --filter @openai/codex run test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*

I have read the CLA Document and I hereby sign the CLA

------
https://chatgpt.com/codex/tasks/task_e_683ff9ea884483309148ea7755c03bec